### PR TITLE
Ensure output frame is CV_8UC3 for VideoWriter, #11

### DIFF
--- a/bin/seek_viewer.cpp
+++ b/bin/seek_viewer.cpp
@@ -50,7 +50,7 @@ void process_frame(Mat &inframe, Mat &outframe, float scale, int colormap, int r
     if (colormap != -1) {
         applyColorMap(frame_g8, outframe, colormap);
     } else {
-        outframe = frame_g8;
+        cv::cvtColor(frame_g8, outframe, cv::COLOR_GRAY2BGR);
     }
 }
 


### PR DESCRIPTION
Ensure seek_viewer creates 3-channel output frame for output, regardless if colormap set.